### PR TITLE
Automated: Update VSCode Extensions

### DIFF
--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -32,12 +32,12 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
     && \ 
     # Manage extensions
     code-server --install-extension ms-python.python@2025.4.0 && \
-    code-server --install-extension ms-python.debugpy@2025.4.0 && \
-    code-server --install-extension REditorSupport.r@2.8.4 && \
-    code-server --install-extension ms-ceintl.vscode-language-pack-fr@1.91.0 && \
-    code-server --install-extension quarto.quarto@1.113.0 && \
-    code-server --install-extension dvirtz.parquet-viewer@2.9.0 && \
-    code-server --install-extension redhat.vscode-yaml@1.15.0 && \
+    code-server --install-extension ms-python.debugpy@2025.6.0 && \
+    code-server --install-extension REditorSupport.r@2.8.6 && \
+    code-server --install-extension ms-ceintl.vscode-language-pack-fr@1.102.0 && \
+    code-server --install-extension quarto.quarto@1.123.0 && \
+    code-server --install-extension dvirtz.parquet-viewer@2.11.2 && \
+    code-server --install-extension redhat.vscode-yaml@1.18.0 && \
     code-server --install-extension ms-vscode.azurecli@0.6.0 && \
     code-server --install-extension mblode.pretty-formatter@0.2.1 && \
     code-server --install-extension cpptools-linux.vsix && \


### PR DESCRIPTION
Update VSCode extensions in Dockerfile:
- ms-python.debugpy: 2025.4.0 -> 2025.6.0
- REditorSupport.r: 2.8.4 -> 2.8.6
- ms-ceintl.vscode-language-pack-fr: 1.91.0 -> 1.102.0
- quarto.quarto: 1.113.0 -> 1.123.0
- dvirtz.parquet-viewer: 2.9.0 -> 2.11.2
- redhat.vscode-yaml: 1.15.0 -> 1.18.0
- cpptools-linux.vsix: 1.20.5 -> 1.25.3
