### PR TITLE
Automated: Update ms-python.debugpy to 2025.6.0

### DIFF
--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -32,7 +32,7 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
     && \ 
     # Manage extensions
     code-server --install-extension ms-python.python@2025.4.0 && \
-    code-server --install-extension ms-python.debugpy@2025.4.0 && \
+    code-server --install-extension ms-python.debugpy@2025.6.0 && \
     code-server --install-extension REditorSupport.r@2.8.4 && \
     code-server --install-extension ms-ceintl.vscode-language-pack-fr@1.91.0 && \
     code-server --install-extension quarto.quarto@1.113.0 && \


### PR DESCRIPTION
This PR updates `ms-python.debugpy` from `2025.4.0` to `2025.6.0`.