### PR TITLE
Automated: Update dvirtz.parquet-viewer to 2.11.2

### DIFF
--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -36,7 +36,7 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
     code-server --install-extension REditorSupport.r@2.8.4 && \
     code-server --install-extension ms-ceintl.vscode-language-pack-fr@1.91.0 && \
     code-server --install-extension quarto.quarto@1.113.0 && \
-    code-server --install-extension dvirtz.parquet-viewer@2.9.0 && \
+    code-server --install-extension dvirtz.parquet-viewer@2.11.2 && \
     code-server --install-extension redhat.vscode-yaml@1.15.0 && \
     code-server --install-extension ms-vscode.azurecli@0.6.0 && \
     code-server --install-extension mblode.pretty-formatter@0.2.1 && \


### PR DESCRIPTION
This PR updates `dvirtz.parquet-viewer` from `2.9.0` to `2.11.2`.